### PR TITLE
Include the host name in Missing WHM hash exception

### DIFF
--- a/lib/lumberg/whm/server.rb
+++ b/lib/lumberg/whm/server.rb
@@ -296,7 +296,7 @@ module Lumberg
       end
 
       def format_hash(hash)
-        raise Lumberg::WhmArgumentError.new("Missing WHM hash") unless hash.is_a?(String)
+        raise Lumberg::WhmArgumentError.new("Missing WHM hash for #{@host}") unless hash.is_a?(String)
         hash.gsub(/\n|\s/, '')
       end
 

--- a/spec/whm/server_spec.rb
+++ b/spec/whm/server_spec.rb
@@ -75,7 +75,7 @@ module Lumberg
     describe "#format_hash" do
       it "raises an error if hash is not a string" do
         expect{  Whm::Server.new(host: @whm_host, hash: nil) }.
-          to raise_error(Lumberg::WhmArgumentError, "Missing WHM hash")
+          to raise_error(Lumberg::WhmArgumentError, "Missing WHM hash for #{@whm_host}")
       end
 
       it "removes \\n's from the hash" do


### PR DESCRIPTION
Includes the host name in the `Missing WHM hash` exceptions to make debugging a little easier