### PR TITLE
Stub DNS resolution of myhost.com in specs

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,6 +34,7 @@ RSpec.configure do |c|
     else
       @whm_hash = 'iscool'
       @whm_host = 'myhost.com'
+      Resolv.stub(:getaddress).with(@whm_host).and_return('11.22.33.44')
     end
   end
 end


### PR DESCRIPTION
The specs are currently failing as the placeholder domain `myhost.com` no longer resolves.