### PR TITLE
Resolv host before checking WHM hash

### DIFF
--- a/lib/lumberg/exceptions.rb
+++ b/lib/lumberg/exceptions.rb
@@ -1,6 +1,8 @@
 module Lumberg
   # WHM Exception for when an argument is invalid, missing, etc.
   class WhmArgumentError < ArgumentError; end
+  # WHM Exception for when a connection fails
+  class WhmConnectionError < ArgumentError; end
   # WHM Exception for when a request is performed on an invalid user
   class WhmInvalidUser < RuntimeError; end
 end

--- a/lib/lumberg/version.rb
+++ b/lib/lumberg/version.rb
@@ -1,3 +1,3 @@
 module Lumberg
-  VERSION = '2.0.1'
+  VERSION = '3.0.0'
 end

--- a/lib/lumberg/whm/server.rb
+++ b/lib/lumberg/whm/server.rb
@@ -58,13 +58,13 @@ module Lumberg
         @ssl_verify ||= false
         @ssl        = options.delete(:ssl)
         @host       = options.delete(:host)
+        validate_server_host
+
         @hash       = format_hash(options.delete(:hash))
         @user       = (options.has_key?(:user) ? options.delete(:user) : 'root')
         @basic_auth = options.delete(:basic_auth)
         @timeout    = options.delete(:timeout)
         @whostmgr   = options.delete(:whostmgr)
-
-        validate_server_host
 
         @base_url = format_url(options)
       end
@@ -257,6 +257,11 @@ module Lumberg
         end.get(function).body
         @force_response_type = nil
         @response
+
+      rescue Faraday::Error::ConnectionFailed, Faraday::TimeoutError
+        raise Lumberg::WhmConnectionError.new(
+          "#{@host} is either unavailable or is not currently accepting requests. Please try again in a few minutes."
+        )
       end
 
       def format_query(hash)

--- a/spec/whm/server_spec.rb
+++ b/spec/whm/server_spec.rb
@@ -43,8 +43,22 @@ module Lumberg
         expect do
           Whm::Server.new(host: "nxdomain.tld", hash: "")
         end.to raise_error(
-         Lumberg::WhmArgumentError, "Unable to resolve nxdomain.tld"
+          Lumberg::WhmArgumentError, "Unable to resolve nxdomain.tld"
         )
+      end
+
+      it "raises message for connection failed" do
+        VCR.turn_off!
+        stub_request(:get, "#{@url_base}/version").to_timeout
+
+        expect do
+          @whm = Whm::Server.new(@login)
+          @whm.version
+        end.to raise_error(
+          Lumberg::WhmConnectionError, "#{@login[:host]} is either unavailable or is not currently accepting requests. Please try again in a few minutes."
+        )
+
+        VCR.turn_on!
       end
     end
 


### PR DESCRIPTION
Sometimes the remote server is unreachable but it still fails with a message like "Missing WHM hash for x.x.x.x". This tries to resolve the host, and raises an exception if it fails, before checking the WHM hash.

Also improves error message when the host is down or unreachable. 