### PR TITLE
Raise WhmConnectionError when cPanel API is unavailable

### DIFF
--- a/lib/lumberg/format_whm.rb
+++ b/lib/lumberg/format_whm.rb
@@ -26,7 +26,15 @@ module Lumberg
                env[:body]
              end
 
-      env[:body] = format_response body
+      if body =~ /cPanel operations have been temporarily suspended/
+        raise Lumberg::WhmConnectionError.new(body)
+      end
+
+      if @type == :whostmgr || response_type(body) == :whostmgr
+        env[:body] = format_response body
+      else
+        env[:body] = format_response JSON.parse(body)
+      end
     end
 
     def response_values(env)

--- a/lib/lumberg/whm/server.rb
+++ b/lib/lumberg/whm/server.rb
@@ -251,7 +251,6 @@ module Lumberg
           c.request :url_encoded
           c.response :format_whm, @force_response_type, @response_key, @boolean_params
           c.response :logger, create_logger_instance
-          c.response :json unless @force_response_type == :whostmgr
           c.adapter :net_http
           c.options[:timeout] = timeout if timeout
         end.get(function).body

--- a/spec/format_whm_spec.rb
+++ b/spec/format_whm_spec.rb
@@ -6,8 +6,9 @@ describe Lumberg::FormatWhm do
 
   context "gzip" do
     let(:gzipped_data) do
-      "\u001F\x8B\b\u0000\u001E¹R\u0000\u0003+\xCE\xCFMUHI,I\u0004\u0000" +
-      "\u001E\xE9\xC2\xD9\t\u0000\u0000\u0000"
+      "\x1F\x8B\b\x00\x13d\x01V\x00\x03\xABV*.MNN-.V\xB2*)*M\xD5Q\xCA" +
+      "\x05\xB2\x13\xD3S\x95\xAC\x94\x8A\xF3sS\x15R\x12K\x12\x95j\x01" +
+      "\xA0E\x91\xF9&\x00\x00\x00"
     end
 
     it "removes content encoding" do
@@ -18,13 +19,14 @@ describe Lumberg::FormatWhm do
 
       env.should_not include "content-encoding"
 
-      env[:body][:params].should eq "some data"
+      env[:body][:params][:message].should eq "some data"
     end
   end
 
   context "deflate" do
     let(:compressed_data) do
-      "x\x9C+\xCE\xCFMUHI,I\x04\x00\x11\x81\x03o"
+      "x\x9C\xABV*.MNN-.V\xB2*)*M\xD5Q\xCA\x05\xB2\x13\xD3S\x95\xAC" +
+      "\x94\x8A\xF3sS\x15R\x12K\x12\x95j\x01\n\xFE\rq"
     end
 
     it "removes content encoding" do
@@ -35,19 +37,28 @@ describe Lumberg::FormatWhm do
 
       env.should_not include "content-encoding"
 
-      env[:body][:params].should eq "some data"
+      env[:body][:params][:message].should eq "some data"
     end
   end
 
   context "no content encoding" do
     it "doesn't touch response headers" do
-      env = { body: "some data", response_headers: { foo: "bar" } }
+      env = { body: "{\"success\":true,\"message\":\"some data\"}",
+              response_headers: { foo: "bar" } }
 
       subject.on_complete(env)
 
       env[:response_headers].should include :foo
 
-      env[:body][:params].should eq "some data"
+      env[:body][:params][:message].should eq "some data"
+    end
+  end
+
+  context "API unavailable" do
+    it "raises a Lumberg::WhmConnectionError" do
+      env = { body: "cPanel operations have been temporarily suspended", response_headers: { foo: "bar" } }
+
+      expect { subject.on_complete(env) }.to raise_error(Lumberg::WhmConnectionError)
     end
   end
 end

--- a/spec/whm/server_spec.rb
+++ b/spec/whm/server_spec.rb
@@ -164,6 +164,7 @@ module Lumberg
 
           before(:each) do
             Net::HTTP.stub(:new) { net_http }
+            JSON.stub(:parse) { { } }
           end
 
           it "sets HTTP timeout when assigned" do


### PR DESCRIPTION
There are some scenarios where cPanel stops accepting API requests (such as when the root filesystem is full). However, HTML is sent back in the JSON response, causing a `JSON::ParseError`.

````ruby
JSON::ParserError: 757: unexpected token at 'Content-type: text/plain; charset="utf-8" <html> <body bgcolor="#FFFFFF"> <h1>Sorry for the inconvenience!</h1> <h3>The filesystem mounted at / on this server is running out of disk space. cPanel operations have been temporarily suspended to prevent something bad from happening. Please ask your system admin to remove any files not in use on that partition.</h3> </body> </html>'
````

With this change, a `WhmConnectionError` is raised instead. 