### PR TITLE
Handle all non-JSON cpanel responses

### DIFF
--- a/spec/format_whm_spec.rb
+++ b/spec/format_whm_spec.rb
@@ -54,9 +54,9 @@ describe Lumberg::FormatWhm do
     end
   end
 
-  context "API unavailable" do
+  context "non-JSON response" do
     it "raises a Lumberg::WhmConnectionError" do
-      env = { body: "cPanel operations have been temporarily suspended", response_headers: { foo: "bar" } }
+      env = { body: "<HTML>Not JSON, for some stupid reason</HTML>", response_headers: { foo: "bar" } }
 
       expect { subject.on_complete(env) }.to raise_error(Lumberg::WhmConnectionError)
     end


### PR DESCRIPTION
Right now, lumberg raises a JSON error for some cpanel API responses that are not formatted as JSON. Since these are error cases, it should should consistently raise a connection error for all of them.